### PR TITLE
use dev version in git

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -14,21 +14,9 @@ version=$1
 
 sed -i "s/__version__ = .*/__version__ = '${version}'/" */__init__.py
 
-# Do not tag/push on Go CD
-if [ -z "$GO_PIPELINE_LABEL" ]; then
-    python3 setup.py clean
-    python3 setup.py test
-    python3 setup.py flake8
-
-    git add */__init__.py
-
-    git commit -m "Bumped version to $version"
-    git push
-fi
+tox
 
 python3 setup.py sdist bdist_wheel upload
 
-if [ -z "$GO_PIPELINE_LABEL" ]; then
-    git tag ${version}
-    git push --tags
-fi
+# revert version
+git co -- */__init__.py

--- a/zalando_aws_cli/__init__.py
+++ b/zalando_aws_cli/__init__.py
@@ -1,1 +1,2 @@
-__version__ = '0.20'
+# This version is replaced during release process.
+__version__ = '2016.0.dev1'


### PR DESCRIPTION
Makes more sense to just have "*dev*" in git and replace the version only on release (we do it with Connexion etc).